### PR TITLE
Loosen the version constrait for doctrine annotations.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "library",
   "require": {
     "php": ">=5.6",
-    "doctrine/annotations": "~1.4.0",
+    "doctrine/annotations": "^1.4.0",
     "ext-json": "*"
   },
   "require-dev": {


### PR DESCRIPTION
Make the version constraint for doctrine/annotations less strict. The caret ^1.4.0 allows for all versions <2.0.